### PR TITLE
Cleaner screenshots persitence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Uncomment or modify the model you want to use:
 
 # Llama 3.2 Vision (Meta's latest vision model)
-OLLAMA_MODEL=llama3.2-vision:latest
+OLLAMA_MODEL=llama3.1
 
 # MiniCPM-V (Fast vision model with good accuracy)
 # OLLAMA_MODEL=minicpm-v:latest
@@ -12,3 +12,9 @@ OLLAMA_MODEL=llama3.2-vision:latest
 
 # Server configuration (usually no need to change)
 OLLAMA_HOST=http://localhost:11434 
+
+# Screenshot configuration
+# SCREENSHOT_DIR=screenshots  # Directory where screenshots will be saved (defaults to system temp directory if not set)
+# SCREENSHOT_MAX_AGE_DAYS=1   # Maximum age in days for screenshots before cleanup (default: 1)
+# SCREENSHOT_MAX_COUNT=10     # Maximum number of screenshots to keep (default: 10)
+# Note: Cleanup happens automatically when capturing screenshots and can be triggered manually via /screenshots/cleanup endpoint 

--- a/llm_control/voice/commands.py
+++ b/llm_control/voice/commands.py
@@ -20,8 +20,7 @@ logger = logging.getLogger("voice-control-commands")
 DEBUG = os.environ.get("DEBUG", "").lower() in ("true", "1", "yes")
 
 # Import from our modules
-from llm_control.voice.utils import clean_llm_response
-from llm_control.voice.utils import get_screenshot_dir
+from llm_control.voice.utils import clean_llm_response, get_screenshot_dir, cleanup_old_screenshots
 from llm_control.voice.prompts import (
     TRANSLATION_PROMPT,
     VERIFICATION_PROMPT,
@@ -634,6 +633,15 @@ def process_command_pipeline(command, model=OLLAMA_MODEL):
         try:
             import pyautogui
             
+            # Clean up old screenshots before capturing a new one
+            max_age_days = int(os.environ.get("SCREENSHOT_MAX_AGE_DAYS", "1"))
+            max_count = int(os.environ.get("SCREENSHOT_MAX_COUNT", "10"))
+            cleanup_count, cleanup_error = cleanup_old_screenshots(max_age_days, max_count)
+            if cleanup_error:
+                logger.warning(f"Error cleaning up screenshots before capture: {cleanup_error}")
+            else:
+                logger.debug(f"Cleaned up {cleanup_count} old screenshots before capture")
+            
             # Capture screenshot
             screenshot = pyautogui.screenshot()
             screenshot_path = os.path.join(get_screenshot_dir(), f"temp_screenshot_{int(time.time())}.png")
@@ -770,6 +778,15 @@ def execute_command_with_logging(command, model=OLLAMA_MODEL, ollama_host=OLLAMA
                 
                 # Capture before screenshot if needed
                 if os.environ.get("CAPTURE_SCREENSHOTS", "true").lower() != "false":
+                    # Cleanup old screenshots before capturing a new one
+                    max_age_days = int(os.environ.get("SCREENSHOT_MAX_AGE_DAYS", "1"))
+                    max_count = int(os.environ.get("SCREENSHOT_MAX_COUNT", "10"))
+                    cleanup_count, cleanup_error = cleanup_old_screenshots(max_age_days, max_count)
+                    if cleanup_error:
+                        logger.warning(f"Error cleaning up screenshots before 'before' capture: {cleanup_error}")
+                    else:
+                        logger.debug(f"Cleaned up {cleanup_count} old screenshots before 'before' capture")
+                    
                     # Take a screenshot before execution
                     before_path = os.path.join(get_screenshot_dir(), f"before_{int(time.time())}.png")
                     pyautogui.screenshot().save(before_path)
@@ -792,6 +809,16 @@ def execute_command_with_logging(command, model=OLLAMA_MODEL, ollama_host=OLLAMA
                 if os.environ.get("CAPTURE_SCREENSHOTS", "true").lower() != "false":
                     # Wait a little for UI to update
                     time.sleep(0.5)
+                    
+                    # Cleanup old screenshots before capturing a new one
+                    max_age_days = int(os.environ.get("SCREENSHOT_MAX_AGE_DAYS", "1"))
+                    max_count = int(os.environ.get("SCREENSHOT_MAX_COUNT", "10"))
+                    cleanup_count, cleanup_error = cleanup_old_screenshots(max_age_days, max_count)
+                    if cleanup_error:
+                        logger.warning(f"Error cleaning up screenshots before 'after' capture: {cleanup_error}")
+                    else:
+                        logger.debug(f"Cleaned up {cleanup_count} old screenshots before 'after' capture")
+                    
                     # Take a screenshot after execution
                     after_path = os.path.join(get_screenshot_dir(), f"after_{int(time.time())}.png")
                     pyautogui.screenshot().save(after_path)

--- a/llm_control/voice/screenshots.py
+++ b/llm_control/voice/screenshots.py
@@ -40,13 +40,6 @@ def capture_screenshot():
         screenshot_dir = get_screenshot_dir()
         logger.debug(f"Using screenshot directory: {screenshot_dir}")
         
-        # Clean up old screenshots
-        cleanup_count, cleanup_error = cleanup_old_screenshots()
-        if cleanup_error:
-            logger.warning(f"Screenshot cleanup warning: {cleanup_error}")
-        else:
-            logger.debug(f"Cleaned up {cleanup_count} old screenshots")
-        
         # Generate a filename based on timestamp
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         filename = f"screenshot_{timestamp}.png"
@@ -115,13 +108,6 @@ def capture_with_highlight(x=None, y=None, width=20, height=20, color='red'):
         # Get the screenshot directory
         screenshot_dir = get_screenshot_dir()
         logger.debug(f"Using screenshot directory: {screenshot_dir}")
-        
-        # Clean up old screenshots
-        cleanup_count, cleanup_error = cleanup_old_screenshots()
-        if cleanup_error:
-            logger.warning(f"Screenshot cleanup warning: {cleanup_error}")
-        else:
-            logger.debug(f"Cleaned up {cleanup_count} old screenshots")
         
         # Generate a filename based on timestamp
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -304,8 +290,8 @@ def manual_cleanup_screenshots(max_age_days=None, max_count=None):
     Manually trigger cleanup of old screenshots.
     
     Args:
-        max_age_days: Maximum age in days for screenshots (defaults to 7 if None)
-        max_count: Maximum number of screenshots to keep (defaults to 100 if None)
+        max_age_days: Maximum age in days for screenshots (defaults to env var SCREENSHOT_MAX_AGE_DAYS or 7)
+        max_count: Maximum number of screenshots to keep (defaults to env var SCREENSHOT_MAX_COUNT or 100)
         
     Returns:
         Dictionary with cleanup results
@@ -313,13 +299,7 @@ def manual_cleanup_screenshots(max_age_days=None, max_count=None):
     logger.info(f"Manually cleaning up screenshots with parameters: max_age_days={max_age_days}, max_count={max_count}")
     
     try:
-        # Use default values if none provided
-        if max_age_days is None:
-            max_age_days = 7
-        if max_count is None:
-            max_count = 100
-            
-        # Call the cleanup function
+        # Call the cleanup function - it will use environment variables if parameters are None
         deleted_count, error = cleanup_old_screenshots(max_age_days, max_count)
         
         # Get the current screenshot count

--- a/llm_control/voice/screenshots.py
+++ b/llm_control/voice/screenshots.py
@@ -194,8 +194,11 @@ def get_latest_screenshots(limit=10):
             logger.debug(f"Created screenshot directory: {screenshot_dir}")
             return []
         
-        # Filter out non-screenshot files
-        screenshots = [f for f in all_files if f.startswith("screenshot_") and f.endswith(".png")]
+        # Filter out non-screenshot files - include all supported patterns
+        screenshots = [f for f in all_files if (f.startswith("screenshot_") or 
+                                               f.startswith("temp_") or 
+                                               f.startswith("before_") or 
+                                               f.startswith("after_")) and f.endswith(".png")]
         logger.debug(f"Found {len(screenshots)} screenshot files")
         
         # Sort by modification time (newest first)
@@ -244,8 +247,11 @@ def list_all_screenshots():
             logger.debug(f"Created screenshot directory: {screenshot_dir}")
             return []
         
-        # Filter out non-screenshot files
-        screenshots = [f for f in all_files if f.startswith("screenshot_") and f.endswith(".png")]
+        # Filter out non-screenshot files - include all supported patterns
+        screenshots = [f for f in all_files if (f.startswith("screenshot_") or 
+                                               f.startswith("temp_") or 
+                                               f.startswith("before_") or 
+                                               f.startswith("after_")) and f.endswith(".png")]
         logger.debug(f"Found {len(screenshots)} screenshot files")
         
         # Get metadata for each screenshot

--- a/llm_control/voice/utils.py
+++ b/llm_control/voice/utils.py
@@ -237,7 +237,11 @@ def cleanup_old_screenshots(max_age_days=None, max_count=None):
         screenshots = []
         try:
             for filename in os.listdir(screenshot_dir):
-                if filename.startswith("screenshot_") and filename.endswith(".png"):
+                # Include all relevant screenshot patterns
+                if (filename.startswith("screenshot_") or 
+                    filename.startswith("temp_") or 
+                    filename.startswith("before_") or 
+                    filename.startswith("after_")) and filename.endswith(".png"):
                     full_path = os.path.join(screenshot_dir, filename)
                     mtime = os.path.getmtime(full_path)
                     mtime_str = datetime.fromtimestamp(mtime).strftime('%Y-%m-%d %H:%M:%S')

--- a/llm_control/voice_control_server.py
+++ b/llm_control/voice_control_server.py
@@ -49,6 +49,10 @@ if __name__ == '__main__':
                         help='Enable PyAutoGUI failsafe (move mouse to upper-left corner to abort)')
     parser.add_argument('--screenshot-dir', type=str, default='.',
                         help='Directory where screenshots will be saved (default: current directory)')
+    parser.add_argument('--screenshot-max-age', type=int, default=1,
+                        help='Maximum age in days for screenshots before cleanup (default: 1)')
+    parser.add_argument('--screenshot-max-count', type=int, default=10,
+                        help='Maximum number of screenshots to keep (default: 10)')
     
     args = parser.parse_args()
     
@@ -61,6 +65,8 @@ if __name__ == '__main__':
     os.environ["CAPTURE_SCREENSHOTS"] = "false" if args.disable_screenshots else "true"
     os.environ["PYAUTOGUI_FAILSAFE"] = "true" if args.enable_failsafe else "false"
     os.environ["SCREENSHOT_DIR"] = args.screenshot_dir
+    os.environ["SCREENSHOT_MAX_AGE_DAYS"] = str(args.screenshot_max_age)
+    os.environ["SCREENSHOT_MAX_COUNT"] = str(args.screenshot_max_count)
     
     # Configure SSL context
     ssl_context = None

--- a/scripts/setup/check_setup.py
+++ b/scripts/setup/check_setup.py
@@ -28,7 +28,7 @@ def check_ollama():
             
             # Load model name from .env if it exists
             load_dotenv()
-            model_name = os.getenv('OLLAMA_MODEL', 'llama3.2-vision:latest')
+            model_name = os.getenv('OLLAMA_MODEL', 'llama3.1')
             
             # Check if the model is installed
             model_names = [model['name'] for model in models['models']]


### PR DESCRIPTION
# Problem

The `/screenshot/capture` endpoint was saving screenshots in an absolutely uncontrolled way, with redundancies and some unchecked naming patterns.

# Changes

- The cleanup screenshot logic has been consolidated across the codebase,
- all screenshot naming patterns are controlled now,
- the default screenshot limits have been reduced (no more than 10, no older than 1 day)

```sh
# see .env.example
SCREENSHOT_MAX_AGE_DAYS=1   # Maximum age in days for screenshots before cleanup (default: 1)
SCREENSHOT_MAX_COUNT=10     # Maximum number of screenshots to keep (default: 10)
# Note: Cleanup happens automatically when capturing screenshots and can be triggered manually via /screenshots/cleanup endpoint 
``